### PR TITLE
Set point cloud subscription to use sensor data QoS

### DIFF
--- a/include/octomap_server2/octomap_server.hpp
+++ b/include/octomap_server2/octomap_server.hpp
@@ -7,6 +7,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <rmw/qos_profiles.h>
 
 #include <visualization_msgs/msg/marker_array.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>

--- a/src/octomap_server.cpp
+++ b/src/octomap_server.cpp
@@ -190,7 +190,7 @@ namespace octomap_server {
     void OctomapServer::subscribe() {
         this->m_pointCloudSub = std::make_shared<
             message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
-                this, "cloud_in");
+                this, "cloud_in", rmw_qos_profile_sensor_data);
 
         auto create_timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
             this->get_node_base_interface(),


### PR DESCRIPTION
Fixes #7 .

QoS for PointCloud2 subscription is set to `rmw_qos_profile_sensor_data`.